### PR TITLE
Don't block the Spotify web player

### DIFF
--- a/spotifyads.txt
+++ b/spotifyads.txt
@@ -20,7 +20,6 @@ js.moatads.com
 log.spotify.com
 media-match.com
 omaze.com
-open.spotify.com
 pagead46.l.doubleclick.net
 pagead2.googlesyndication.com
 partner.googleadservices.com
@@ -28,7 +27,6 @@ pubads.g.doubleclick.net
 redirector.gvt1.com
 s0.2mdn.net
 securepubads.g.doubleclick.net
-spclient.wg.spotify.com
 tpc.googlesyndication.com
 v.jwpcdn.com
 video-ad-stats.googlesyndication.com


### PR DESCRIPTION
open.spotify.com, spclient.wg.spotify.com are (apparently) required for the web player to work

I'm a subscriber so I don't know whether ads for "free" accounts are still being blocked (assuming they were before).